### PR TITLE
Handle multiline value

### DIFF
--- a/usr/share/zookeeper-util/bin/zk_import.rb
+++ b/usr/share/zookeeper-util/bin/zk_import.rb
@@ -71,7 +71,7 @@ else
       zk.create_path(a[0].chomp)
     elsif(a.size == 2)
       puts "# Writing data '#{a[1]}' to Path #{a[0]}" if options[:verbose]
-      zk.set_data(a[0].chomp, a[1].chomp)
+      zk.set_data(a[0].chomp, JSON.load(a[1]).encode('ISO-8859-1'))
     else
       puts "#{line} is broken"
     end

--- a/usr/share/zookeeper-util/bin/zookeeper.rb
+++ b/usr/share/zookeeper-util/bin/zookeeper.rb
@@ -1,4 +1,5 @@
 require 'java'
+require 'json'
 
 share_dir = File.dirname(File.dirname(File.dirname(__FILE__)))
 Dir.glob(File.join(share_dir, "java/zookeeper-util/*jar")).each {|p| $CLASSPATH << p}
@@ -88,7 +89,7 @@ module Zookeeper
         stat = Stat.new
         new_path = File.join(path, node)
         d = @zk.get_data(new_path, false, stat) || ''.to_java_bytes
-        node_data = "#{String.from_java_bytes(d)}"
+        node_data = "#{String.from_java_bytes(d)}".force_encoding("ISO-8859-1").encode("UTF-8").to_json
         puts node_data.to_s.empty? ? "#{new_path}" : "#{new_path}#{separator}#{node_data}"
 
         dump(new_path, separator) unless (stat.getNumChildren == 0)


### PR DESCRIPTION
Hi, I'd like to suggest PR to handle issue when value in zookeeper is containing newline character.
Because import util reads entry line by line, import does not work properly if value is containing newline. This PR handle this issue by encoding value by JSON.
