### PR TITLE
Use base64 encoding to support dump and import binary data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM java:openjdk-8
+
+COPY usr /usr
+
+ADD https://s3.amazonaws.com/jruby.org/downloads/1.7.22/jruby-complete-1.7.22.jar /usr/share/java/zookeeper-util/
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+ENTRYPOINT ["/usr/bin/zkutil"]

--- a/README.textile
+++ b/README.textile
@@ -60,3 +60,31 @@ Usage: zk_purge.rb [options] -c <host:port>
     -v, --verbose                    Output more information
     -h, --help                       Display this screen
 
+h5. Docker
+
+A Dockerfile is added to easy package and use this tool. You can checkout this repo and build a docker image like this:
+
+bc. $ docker build -t gengmao/zookeeper-util .
+Sending build context to Docker daemon 17.85 MB
+Step 0 : FROM java:openjdk-8
+ ---> c1ccce98b537
+Step 1 : COPY usr /usr
+ ---> Using cache
+ ---> ce7c545aa779
+Step 2 : ADD https://s3.amazonaws.com/jruby.org/downloads/1.7.22/jruby-complete-1.7.22.jar /usr/share/java/zookeeper-util/
+Downloading [==================================================>] 23.72 MB/23.72 MB
+ ---> Using cache
+ ---> c2e854f67dc7
+Step 3 : ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ ---> Using cache
+ ---> 0e4583859950
+Step 4 : ENTRYPOINT /usr/bin/zkutil
+ ---> Using cache
+ ---> da8f8a8c682d
+Successfully built da8f8a8c682d
+
+Then you can use the image like this:
+
+bc. $ docker run -it gengmao/zookeeper-util
+Usage: zkutil <dump|import|purge> -c host:port [options]
+

--- a/usr/share/zookeeper-util/bin/zk_import.rb
+++ b/usr/share/zookeeper-util/bin/zk_import.rb
@@ -71,7 +71,7 @@ else
       zk.create_path(a[0].chomp)
     elsif(a.size == 2)
       puts "# Writing data '#{a[1]}' to Path #{a[0]}" if options[:verbose]
-      zk.set_data(a[0].chomp, a[1].chomp)
+      zk.set_data(a[0].chomp, javax.xml.bind.DatatypeConverter.parseBase64Binary(a[1]))
     else
       puts "#{line} is broken"
     end

--- a/usr/share/zookeeper-util/bin/zookeeper.rb
+++ b/usr/share/zookeeper-util/bin/zookeeper.rb
@@ -87,10 +87,13 @@ module Zookeeper
         next if path.eql?('/') && node.eql?('zookeeper')
         stat = Stat.new
         new_path = File.join(path, node)
-        d = @zk.get_data(new_path, false, stat) || ''.to_java_bytes
-        node_data = "#{String.from_java_bytes(d)}"
-        puts node_data.to_s.empty? ? "#{new_path}" : "#{new_path}#{separator}#{node_data}"
-
+        d = @zk.get_data(new_path, false, stat)
+        if d == nil or d.length == 0
+          puts "#{new_path}"
+        else
+          node_data = "#{javax.xml.bind.DatatypeConverter.printBase64Binary(d)}"
+          puts "#{new_path}#{separator}#{node_data}"
+        end
         dump(new_path, separator) unless (stat.getNumChildren == 0)
       end
     end


### PR DESCRIPTION
Some of my zookeeper nodes have binary data. When I dumped them out and import back, I hit following exception. 

```
ArgumentError: invalid byte sequence in UTF-8
         =~ at org/jruby/RubyRegexp.java:1657
     (root) at /home/mao/zookeeper-util/usr/share/zookeeper-util/bin/zk_import.rb:64
  each_line at org/jruby/RubyIO.java:3547
     (root) at /home/mao/zookeeper-util/usr/share/zookeeper-util/bin/zk_import.rb:63
```

Then I studied source code and https://github.com/sroegner/zookeeper-util/pull/7, found the binary data was not processed correctly. As the dump file is only parsed as text file when import, the binary data need to be encoded in a revertible text format, for example base64. 
With this PR, multi-lines node data can be imported too. Just one drawback - node data in the dump file are not readable any more. 
